### PR TITLE
Change the way wallets are included

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,21 @@ var request = require('request-promise');
 
 module.exports = (function (data) {
   var walletModule;
+  var requestNewToken = function () {
+    return request({
+      json: true,
+      method: 'POST',
+      uri: data.uri + '/token',
+      body: data.credentials
+    }).then(function (response) {
+      if (wallet) {
+        wallet.write(response);  
+      }
 
-  if (!data.wallet) {
-    return requestNewToken();
-  }
-
+      return Promise.resolve(response.accessToken);
+    });
+  };
+  
   if (typeof data.wallet === 'string') {
     if (data.wallet === 'none') {
       return requestNewToken();
@@ -17,21 +27,12 @@ module.exports = (function (data) {
     walletModule = data.wallet;
   }
 
+  if (!walletModule) {
+    return requestNewToken();
+  }
+
   var Wallet = walletModule;
   var wallet = new Wallet(data.walletOptions);
-
-  var requestNewToken = function () {
-    return request({
-      json: true,
-      method: 'POST',
-      uri: data.uri + '/token',
-      body: data.credentials
-    }).then(function (response) {
-      wallet.write(response);
-
-      return Promise.resolve(response.accessToken);
-    });
-  };
 
   try {
     var token = wallet.read();

--- a/index.js
+++ b/index.js
@@ -1,11 +1,23 @@
 var request = require('request-promise');
 
 module.exports = (function (data) {
-  if (!data.wallet || (data.wallet === 'none')) {
+  var walletModule;
+
+  if (!data.wallet) {
     return requestNewToken();
   }
 
-  var Wallet = data.wallet;
+  if (typeof data.wallet === 'string') {
+    if (data.wallet === 'none') {
+      return requestNewToken();
+    } else {
+      walletModule = require(__dirname + '/wallets/' + data.wallet);
+    }
+  } else {
+    walletModule = data.wallet;
+  }
+
+  var Wallet = walletModule;
   var wallet = new Wallet(data.walletOptions);
 
   var requestNewToken = function () {


### PR DESCRIPTION
Currently, a token wallet is included as such:

``` js
var passport = require('dadi-passport')({
    // (...)
    wallet: require('./wallets/file'), // <-- function
    walletOptions: {
        path: './token.txt'
    }
});
```

This has the disadvantage of forcing users to know the location of the wallet module, which you shouldn't really care about if you're including the library with npm. 

For that reason, I shifted the responsibility of including the wallet file to the library itself, asking users to simply specify the name of the wallet as a string (e.g. `'file'`), which will link to `/wallets/file.js`. The previous syntax is still accepted for people that wish to implement their own wallet modules (which will live outside the library directory).

Example:

``` js
// Using the `file` wallet (new syntax)
var passport = require('dadi-passport')({
    uri: 'http://api.eb.dev.dadi.technology',
    credentials: {
        clientId: 'johndoe',
        secret: 'f00b4r'        
    },
    wallet: 'file', // <-- string
    walletOptions: {
        path: './token.txt'
    }
});

// Using a custom wallet (existing syntax)
var passport = require('dadi-passport')({
    uri: 'http://api.eb.dev.dadi.technology',
    credentials: {
        clientId: 'johndoe',
        secret: 'f00b4r'        
    },
    wallet: require('./lib/my-custom-wallet'), // <-- function
    walletOptions: {
        path: './token.txt'
    }
});
```
