### PR TITLE
Add request injection option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (function (data, requestAgent) {
 
         if (typeof arguments[0] === 'string') {
           // The first pararameter is a URL string
-          requestOptions.url = arguments[0];
+          requestOptions.uri = arguments[0];
           requestOptions.headers = {
             'Authorization': 'Bearer ' + token
           }

--- a/index.js
+++ b/index.js
@@ -1,49 +1,88 @@
 var request = require('request-promise');
 
-module.exports = (function (data) {
-  var walletModule;
-  var requestNewToken = function () {
+module.exports = (function (data, requestAgent) {
+  var Passport = function (data, requestAgent) {
+    this.data = data;
+    this.requestAgent = requestAgent;
+
+    if (typeof data.wallet === 'function') {
+      this.walletModule = data.wallet;
+    } else if ((typeof data.wallet === 'string') && (data.wallet !== 'none')) {
+      this.walletModule = require(__dirname + '/wallets/' + data.wallet);
+    }
+  };
+
+  Passport.prototype.requestToken = function () {
     return request({
       json: true,
       method: 'POST',
       uri: data.uri + '/token',
       body: data.credentials
-    }).then(function (response) {
-      if (wallet) {
-        wallet.write(response);  
+    }).then((function (response) {
+      if (this.wallet) {
+        this.wallet.write(response);
       }
 
-      return Promise.resolve(response.accessToken);
-    });
+      return Promise.resolve(this.return(response.accessToken));
+    }).bind(this));
   };
-  
-  if (typeof data.wallet === 'string') {
-    if (data.wallet === 'none') {
-      return requestNewToken();
+
+  Passport.prototype.return = function (token) {
+    if (this.requestAgent) {
+      return function () {
+        var requestOptions = {};
+
+        if (typeof arguments[0] === 'string') {
+          // The first pararameter is a URL string
+          requestOptions.url = arguments[0];
+          requestOptions.headers = {
+            'Authorization': 'Bearer ' + token
+          }
+        } else {
+          requestOptions = arguments[0];
+
+          // The first argument is an options object
+          if ('headers' in requestOptions) {
+            requestOptions.headers['Authorization'] = 'Bearer ' + token;
+          } else {
+            requestOptions.headers = {
+              'Authorization': 'Bearer ' + token
+            }
+          }
+        }
+
+        arguments[0] = requestOptions;
+
+        return requestAgent.apply(this, arguments);
+      };
     } else {
-      walletModule = require(__dirname + '/wallets/' + data.wallet);
+      return token;
     }
-  } else {
-    walletModule = data.wallet;
-  }
+  };
 
-  if (!walletModule) {
-    return requestNewToken();
-  }
-
-  var Wallet = walletModule;
-  var wallet = new Wallet(data.walletOptions);
-
-  try {
-    var token = wallet.read();
-    var currentDate = Math.floor(Date.now() / 1000);
-
-    if (token.expirationDate > currentDate) {
-      return Promise.resolve(token.accessToken);
-    } else {
-      return requestNewToken();
+  Passport.prototype.get = function () {
+    if (!this.walletModule) {
+      return this.requestToken();
     }
-  } catch (e) {
-    return requestNewToken();
-  }
+
+    var Wallet = this.walletModule;
+    this.wallet = new Wallet(this.data.walletOptions);
+
+    try {
+      var token = this.wallet.read();
+      var currentDate = Math.floor(Date.now() / 1000);
+
+      if (token.expirationDate > currentDate) {
+        return Promise.resolve(this.return(token.accessToken));
+      } else {
+        return this.requestToken();
+      }
+    } catch (e) {
+      return this.requestToken();
+    }
+  };
+
+  var passport = new Passport(data, requestAgent);
+
+  return passport.get();
 });


### PR DESCRIPTION
I've been toying with the idea of extending the capabilities of this library to not only return a valid bearer token on every call, but to inject it into a request.

Currently, this would be a typical use case:

``` js
var request = require('request-promise');
var passport = require('dadi-passport')({
    uri: 'http://api.eb.dev.dadi.technology',
    credentials: {
        clientId: 'johndoe',
        secret: 'f00b4r'
    },
    wallet: 'file',
    walletOptions: {
        path: './token.txt'
    }
});

passport.then(function (bearerToken) {
    request({
        url: 'http://api.eb.dev.dadi.technology/v1/some/endpoint',
        headers: {
            'Authorization': 'Bearer ' + bearerToken
        }
    }).then(function (response) {
        // Do something
    });
});
```

With the functionality I propose, the library will inject the authorisation headers automatically if it gets passed a module that makes the request (the request agent).

_Example:_

``` js
var request = require('request-promise');
var passport = require('dadi-passport')({
    uri: 'http://api.eb.dev.dadi.technology',
    credentials: {
        clientId: 'johndoe',
        secret: 'f00b4r'
    },
    wallet: 'file',
    walletOptions: {
        path: './token.txt'
    }
}, request); // <--- passing the request module as 2nd argument

// The Promise now returns a request object with the authorisation headers injected,
// instead of the bearer token
passport.then(function (request) {
    request('http://api.eb.dev.dadi.technology/v1/some/endpoint').then(function (response) {
        // Do something
    });
});
```

Because libraries like [request](https://www.npmjs.com/package/request) and [request-promise](https://www.npmjs.com/package/request-promise) accept either a string as a single argument — representing the URL — or an options object with `url` as one of the properties, the library analyses the first argument passed to the request agent and injects the authorisation headers accordingly. It can be used with any variation of the `request` module as long as its syntax is the same. 

If no second argument (request agent) is passed, Passport will carry on returning a bearer token as a string, meaning the current API is respected.

I'm aiming to make it really easy and convenient for someone to integrate their scripts with our platform, whilst at the same time trying to keep this library simple and lightweight. It'd be great to hear some thoughts on this.
