### PR TITLE
Add error responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = (function (data, requestAgent) {
       }
 
       return Promise.resolve(this.return(response.accessToken));
+    }).bind(this)).catch((function (errorData) {
+      return Promise.reject(this.createErrorObject(errorData));
     }).bind(this));
   };
 
@@ -80,6 +82,30 @@ module.exports = (function (data, requestAgent) {
     } catch (e) {
       return this.requestToken();
     }
+  };
+
+  Passport.prototype.createErrorObject = function (errorData) {
+    var error = {};
+
+    switch (errorData.statusCode) {
+      case 401:
+        error.status = 'Unauthorized';
+        error.title = 'Credentials not found or invalid';
+        error.detail = 'The authorization process failed for the clientId/secret pair provided';
+        error.code = '';
+
+        break;
+
+      case 404:
+        error.status = 'Not found';
+        error.title = 'URL not found';
+        error.detail = 'The request for URL \'' + errorData.options.uri + '\' returned a 404.';
+        error.code = '';
+
+        break;
+    }
+
+    return error;
   };
 
   var passport = new Passport(data, requestAgent);


### PR DESCRIPTION
This implements error responses as per #7. Errors that happen when requesting a new token will make the Promise reject, sending back an object following the [JSON API format](http://jsonapi.org/format/#errors).

_Example:_

``` js
// `passport` was initialised with an incorrect URL
passport.then(function (bearer) {
    console.log('Bearer token: ' + bearer);
}).catch(function (error) {
    console.log(error);
});
```

_Returns:_

``` js
{ status: 'Not found',
  title: 'URL not found',
  detail: 'The request for URL \'http://fake-api.eb.dev.dadi.technology/token\' returned a 404.',
  code: '' }
```

So far it's forming proper error objects for `401` and `404` only, so I suppose the next step is to make it handle more types of error.

@jimlambie are you happy with this?
