### PR TITLE
Add new issuer field as per DADI conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,23 @@ module.exports = (function (data, requestAgent) {
   };
 
   Passport.prototype.requestToken = function () {
+    var uri = this.data.issuer.uri;
+
+    if (this.data.issuer.port) {
+      uri += ':' + this.data.issuer.port;
+    }
+
+    if (this.data.issuer.endpoint) {
+      uri += this.data.issuer.endpoint;
+    } else {
+      uri += '/token';
+    }
+
     return request({
       json: true,
       method: 'POST',
-      uri: data.uri + '/token',
-      body: data.credentials
+      uri: uri,
+      body: this.data.credentials
     }).then((function (response) {
       if (this.wallet) {
         this.wallet.write(response);


### PR DESCRIPTION
Both @mingard and @jimlambie suggested it would be a good idea to separate the URI string into an object with host, port and endpoint, for consistency with other DADI components.

As such, the options object passed to Passport would look like:

``` js
var passport = require('dadi-passport')({
    issuer: {
        uri: 'http://my-api.eb.dev.dadi.technology',
        port: 80, // Optional. Default: 80
        endpoint: '/token' // Optional. Default: /token
    },
    credentials: {
        clientId: 'johndoe',
        secret: 'f00b4r'
    },
    wallet: 'file',
    walletOptions: {
        path: './token.txt'
    }
});
```

Please note that this change would break the current API, so it's important to inform anyone that might be using the library in their projects until we have a proper release cycle with semver in place.

Thoughts?
