### PR TITLE
Add PHP docs and update folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ This library can be used by third-party applications that wish to integrate with
 * [Requirements](docs/php/requirements.md)
 * [Installation](docs/php/installation.md)
 * [Usage examples](docs/php/usageExamples.md)
+* [Testing](docs/php/testing.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-DADI Passport is a promise-based library for generating access tokens to authenticate with DADI platform components.
+DADI Passport is a library for generating access tokens to authenticate with DADI platform components.
 
 Various components within the DADI stack implement 2-legged oAuth2, requiring a bearer token to authorise requests. This bearer token is obtained as a response sent to a specific endpoint with a clientId/secret pair, along with a TTL defined by the provider.
 
@@ -12,10 +12,21 @@ This library can be used by third-party applications that wish to integrate with
 
 ## Contents
 
-* Overview (this document)
-* [Requirements](https://github.com/dadi/passport/blob/docs/docs/requirements.md)
-* [Token wallets](https://github.com/dadi/passport/blob/docs/docs/tokenWallets.md)
-* [Usage examples](https://github.com/dadi/passport/blob/docs/docs/usageExamples.md)
-* [Development](https://github.com/dadi/passport/blob/docs/docs/development.md)
-* [License](https://github.com/dadi/passport/blob/docs/docs/license.md)
-* [GPL](https://github.com/dadi/passport/blob/docs/docs/gpl.md)
+### Overview
+
+* [Token wallets](docs/tokenWallets.md)
+* [Development](docs/development.md)
+* [License](docs/license.md)
+* [GPL](docs/gpl.md)
+
+### Node.js
+
+* [Requirements](docs/node/requirements.md)
+* [Installation](docs/node/installation.md)
+* [Usage examples](docs/node/usageExamples.md)
+
+### PHP
+
+* [Requirements](docs/php/requirements.md)
+* [Installation](docs/php/installation.md)
+* [Usage examples](docs/php/usageExamples.md)

--- a/docs/node/installation.md
+++ b/docs/node/installation.md
@@ -1,0 +1,33 @@
+# DADI Passport
+
+## Node.js
+
+### Installation
+
+1. Install with NPM:
+
+	```
+	npm install
+	```
+
+1. Include with `require`:
+	
+	```js
+	var passport = require('dadi-passport')({
+		uri: 'http://my-api.dadi.tech',
+		credentials: {
+			clientId: 'johndoe',
+			secret: 'f00b4r'		
+		},
+		wallet: 'file',
+		walletOptions: {
+			path: './token.txt'
+		}
+	});
+
+	passport.then(function (bearerToken) {
+	    // Authorised request goes here...
+	});
+	```
+
+For more examples, see [usageExamples.md](Usage examples).

--- a/docs/node/installation.md
+++ b/docs/node/installation.md
@@ -4,13 +4,13 @@
 
 ### Installation
 
-1. Install with NPM:
+1. Install with [npm](https://www.npmjs.com/:
 
 	```
 	npm install
 	```
 
-1. Include with `require`:
+2. Include with `require`:
 	
 	```js
 	var passport = require('dadi-passport')({

--- a/docs/node/requirements.md
+++ b/docs/node/requirements.md
@@ -1,0 +1,7 @@
+# DADI Passport
+
+## Node.js
+
+### Requirements
+
+- Node.js (`>= 0.12`)

--- a/docs/node/usageExamples.md
+++ b/docs/node/usageExamples.md
@@ -1,6 +1,8 @@
 # DADI Passport
 
-## Usage examples
+## Node.js
+
+### Usage examples
 
 Passport will return different things based on the arity of its require call. If there is only one argument, the return value will be a Promise containing a string with a bearer token.
 

--- a/docs/php/installation.md
+++ b/docs/php/installation.md
@@ -4,7 +4,7 @@
 
 ### Installation
 
-1. Install with [Composer](https://getcomposer.org/:
+1. Install with [Composer](https://getcomposer.org/):
 
 	```
 	composer require dadi/passport:dev-master
@@ -18,7 +18,7 @@
 	}
 	```
 
-1. Require via autoloading:
+2. Require via autoloading:
 	
 	```php
 	require 'vendor/autoload.php';

--- a/docs/php/installation.md
+++ b/docs/php/installation.md
@@ -1,0 +1,45 @@
+# DADI Passport
+
+## PHP
+
+### Installation
+
+1. Install with [Composer](https://getcomposer.org/:
+
+	```
+	composer require dadi/passport:dev-master
+	```
+
+	Or include in `composer.json`:
+
+	```
+	"require": {
+		"dadi/passport": "dev-master"
+	}
+	```
+
+1. Require via autoloading:
+	
+	```php
+	require 'vendor/autoload.php';
+
+	$options = array(
+		'issuer' => array(
+			'uri' => 'http://my-api.dadi.tech',
+			'port' => 80,
+			'endpoint' => '/token'
+		),
+		'credentials' => array(
+			'clientId' => 'johndoe',
+			'secret' => 'f00b4r'
+		),
+		'wallet' => '\dadi\PassportFileWallet',
+		'walletOptions' => array(
+			'path' => 'token.txt'
+		)
+	);
+
+	$bearerToken = \dadi\Passport::get($options);
+	```
+
+For more examples, see [usageExamples.md](Usage examples).

--- a/docs/php/requirements.md
+++ b/docs/php/requirements.md
@@ -1,0 +1,7 @@
+# DADI Passport
+
+## PHP
+
+### Requirements
+
+- PHP (`>= 5.2`)

--- a/docs/php/testing.md
+++ b/docs/php/testing.md
@@ -1,0 +1,9 @@
+# DADI Passport
+
+## PHP
+
+### Testing
+
+Passport uses [PHPUnit](https://phpunit.de/) for unit testing.
+
+To run tests, run `composer test`.

--- a/docs/php/usageExamples.md
+++ b/docs/php/usageExamples.md
@@ -1,0 +1,61 @@
+# DADI Passport
+
+## Usage examples
+
+Passport will expose a single method (`get()`), which will return different things based on the arity of its call. If there is only one argument, the return value will be a string with a bearer token.
+
+*Getting a bearer token:*
+
+```php
+$options = array(
+    'issuer' => array(
+        'uri' => 'http://my-api.dadi.tech',
+        'port' => 80, // Optional. Defaults to 80
+        'endpoint' => '/token' // Optional. Defaults to '/token'
+    ),
+    'credentials' => array(
+        'clientId' => 'johndoe',
+        'secret' => 'f00b4r'
+    ),
+    'wallet' => '\dadi\PassportFileWallet',
+    'walletOptions' => array(
+        'path' => 'token.txt'
+    )
+);
+
+$bearerToken = \dadi\Passport::get($options);
+```
+
+If a function is passed as a second argument, Passport will return an instance of a class capable of making an HTTP request, with the authorisation headers automatically injected. At present, only [cURL](http://php.net/manual/en/book.curl.php) is supported, but other implementations can be added in the future.
+
+*Using request injection option with cURL:*
+
+```php
+$options = array(
+    'issuer' => array(
+        'uri' => 'http://my-api.dadi.tech',
+        'port' => 80, // Optional. Defaults to 80
+        'endpoint' => '/token' // Optional. Defaults to '/token'
+    ),
+    'credentials' => array(
+        'clientId' => 'johndoe',
+        'secret' => 'f00b4r'
+    ),
+    'wallet' => '\dadi\PassportFileWallet',
+    'walletOptions' => array(
+        'path' => 'token.txt'
+    )
+);
+
+$request = \dadi\Passport::get($options, 'curl');
+
+// Making an API call with the cURL instance
+curl_setopt($request, CURLOPT_URL, "http://my-api.dadi.tech/v1/test/collection");
+curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+print($response);
+```


### PR DESCRIPTION
This PR updates the documentation branch, adding details about the PHP implementation and updating the folder structure to be as following:

```
.
├── Main README w/ table of contents
└── docs/
    ├── Token wallets
    ├── Development
    ├── License
    ├── GPL
    ├── node/
    |   ├── Installation
    |   ├── Requirements
    |   └── Usage examples
    └── php/
        ├── Installation
        ├── Requirements
        └── Usage examples
```
