### PR TITLE
Add HTTP/2 support to Node implementation

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -4,6 +4,7 @@
   "description": "A library for generating access tokens to authenticate with DADI platform components",
   "main": "src/index.js",
   "dependencies": {
+    "http2": "^3.3.2",
     "request-promise": "^2.0.0"
   },
   "devDependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/passport",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A library for generating access tokens to authenticate with DADI platform components",
   "main": "src/index.js",
   "dependencies": {

--- a/node/src/index.js
+++ b/node/src/index.js
@@ -36,8 +36,10 @@ module.exports = (function (data, requestAgent) {
 
   Passport.prototype.fetchTokenHTTP2 = function (uri) {
     var payload = JSON.stringify(this.data.credentials);
+    var host = (this.data.issuer.uri.indexOf('https://') === 0) ? this.data.issuer.uri.substring(8) : this.data.issuer.uri;
+
     var options = {
-      host: this.data.issuer.uri,
+      host: host,
       port: this.data.issuer.port || 443,
       path: this.data.issuer.endpoint || '/token',
       method: 'POST',

--- a/node/src/index.js
+++ b/node/src/index.js
@@ -1,3 +1,4 @@
+var http2 = require('http2');
 var request = require('request-promise');
 
 module.exports = (function (data, requestAgent) {
@@ -12,7 +13,7 @@ module.exports = (function (data, requestAgent) {
     }
   };
 
-  Passport.prototype.requestToken = function () {
+  Passport.prototype.fetchTokenHTTP1 = function () {
     var uri = this.data.issuer.uri;
 
     if (this.data.issuer.port) {
@@ -30,7 +31,54 @@ module.exports = (function (data, requestAgent) {
       method: 'POST',
       uri: uri,
       body: this.data.credentials
-    }).then((function (response) {
+    });
+  };
+
+  Passport.prototype.fetchTokenHTTP2 = function (uri) {
+    var payload = JSON.stringify(this.data.credentials);
+    var options = {
+      host: this.data.issuer.uri,
+      port: this.data.issuer.port || 443,
+      path: this.data.issuer.endpoint || '/token',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': payload.length
+      }
+    };
+
+    if (this.data.ca) {
+      options.ca = this.data.ca;
+    }
+
+    return new Promise(function (resolve, reject) {
+      var response = '';
+
+      var req = http2.request(options, function (res) {
+        res.on('data', function (chunk) {
+          response += chunk.toString();
+        });
+
+        res.on('end', function () {
+          try {
+            var parsedResponse = JSON.parse(response);
+
+            resolve(parsedResponse);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      req.write(payload);
+      req.end();
+    });
+  };
+
+  Passport.prototype.requestToken = function () {
+    var fetchMethod = this.data.http2 ? this.fetchTokenHTTP2.bind(this) : this.fetchTokenHTTP1.bind(this);
+
+    return fetchMethod().then((function (response) {
       if (this.wallet) {
         this.wallet.write(response);
       }


### PR DESCRIPTION
This PR adds HTTP/2 support to the Node.js implementation of Passport. 

Usage is as follows:

``` js
var certificate = fs.readFileSync('./../api/config/example/localhost.crt');

var passportOptions = {
    issuer: {
        uri: 'localhost',
        port: 3000,           // Optional. Defaults to 80 when HTTP/1.x, 443 when HTTP/2
        endpoint: '/token'    // Optional. Defaults to '/token'
    },
    credentials: {
        clientId: 'testClient',
        secret: 'superSecret'
    },
    wallet: 'file',
    walletOptions: {
        path: './token.txt'
    },
    http2: true,              // Indicates that the request should be done through HTTP/2
    ca: certificate           // Optional. Uses a self-signed certificate
};
```

Existing tests are passing. I haven't had the chance to add any tests for the new feature yet. I'll do this over the next couple of days, but I wanted to push this branch asap as @kevinsowers223 needs this feature for Web.

@jimlambie @kevinsowers223 let me know your thoughts.

Thanks!
